### PR TITLE
Feat: added .editorconfig file

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,13 @@
+# http://editorconfig.org
+root = true
+
+[*.{yml,yaml,dart,json,gitignore}]
+indent_style = space
+indent_size = 2
+end_of_line = lf
+charset = utf-8
+trim_trailing_whitespace = true
+insert_final_newline = true
+
+[*.md]
+trim_trailing_whitespace = false

--- a/.editorconfig
+++ b/.editorconfig
@@ -1,7 +1,7 @@
 # http://editorconfig.org
 root = true
 
-[*.{yml,yaml,dart,json,gitignore}]
+[*.{yml,yaml,json,gitignore}]
 indent_style = space
 indent_size = 2
 end_of_line = lf

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,3 @@
+{
+  "editor.formatOnSave": true,
+}


### PR DESCRIPTION
http://editorconfig.org
Install the Editorconfig plugin for your editor to use the plugin.

Editorconfig cleans up trailing whitespace for you, and it also enforces indentation style, character set, and more, for that extra level of tidiness.

I added this because there's whitespace and newline inconsistencies that happen. This is pretty much the best solution so the settings set in .editorconfig carry across all of our editors with the plugin installed.